### PR TITLE
Update ServoSmooth.cpp

### DIFF
--- a/libraries/ServoSmooth/ServoSmooth.cpp
+++ b/libraries/ServoSmooth/ServoSmooth.cpp
@@ -104,7 +104,10 @@ boolean ServoSmooth::tickManual() {
 			_servo.writeMicroseconds((int)_newPos);									// отправляем на серво
 		}			
 	}
-	if (abs(_servoTargetPos - (int)_newPos) < SS_DEADZONE) {		
+	if (abs(_servoTargetPos - (int)_newPos) < SS_DEADZONE) {	
+		if (_servoTargetPos == (int)_newPos){						//Случай когда текущая позиция совпадает с позицией таргета
+			_servoState = true;										//tick() не когда не вернет true, режим вечного доезжания
+		}	
 		if (_autoDetach && _servoState) {			
 			if (_timeoutCounter > SS_TIMEOUT) {
 				_newPos = _servoTargetPos;
@@ -127,9 +130,9 @@ boolean ServoSmooth::tickManual() {
 }
 
 boolean ServoSmooth::tick() {
-	if (millis() - _prevServoTime >= SS_SERVO_PERIOD) {
-		_prevServoTime = millis();
-		if (ServoSmooth::tickManual()) return true;
-		else return false;
-	}
+    if (millis() - _prevServoTime >= SS_SERVO_PERIOD) {
+        _prevServoTime = millis();
+        return ServoSmooth::tickManual();
+    }
+    return false;
 }


### PR DESCRIPTION
1. Если вызывается поворот на угол или длительностью равным текущей позиции сервы, то ServoSmooth::tick() не когда не вернет true потому как его не вернет ServoSmooth::tickManual(). Что бы вернулось true (или "серва приехала") нужно _servoState иметь true, а оно выставляется только в случае если не выполняется условие abs(_servoTargetPos - (int)_newPos) < SS_DEADZONE, а если _servoTargetPos = _newPos, то условие выполняется, и значение true не когда не будет достигнуто.
2. boolean должен возвращать true или false. Если не выполняется millis() - _prevServoTime >= SS_SERVO_PERIOD, то функция ничего не возвращает (вернее ахинею возвращает). И ServoSmooth::tickManual() тоже boolean, потому её не обязательно проверять.